### PR TITLE
Add teams and donations

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -33,7 +33,7 @@ export function startGame(map: GameMap) {
 	playerNameRenderingManager.reset();
 	attackActionHandler.init(500);
 	spawnManager.init(500);
-	playerManager.init([new Player(0, "Player")], 0, 500, 10);
+	playerManager.init([new Player(0, "Player")], 0, 500, 0);
 
 	isLocalGame = true;
 	random.reset(23452345);

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -33,7 +33,7 @@ export function startGame(map: GameMap) {
 	playerNameRenderingManager.reset();
 	attackActionHandler.init(500);
 	spawnManager.init(500);
-	playerManager.init([new Player(0, "Player")], 0, 500, true);
+	playerManager.init([new Player(0, "Player")], 0, 500, 10);
 
 	isLocalGame = true;
 	random.reset(23452345);

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -33,7 +33,7 @@ export function startGame(map: GameMap) {
 	playerNameRenderingManager.reset();
 	attackActionHandler.init(500);
 	spawnManager.init(500);
-	playerManager.init([new Player(0, "Player", 0, 200, 200)], 0, 500);
+	playerManager.init([new Player(0, "Player")], 0, 500, true);
 
 	isLocalGame = true;
 	random.reset(23452345);

--- a/src/game/Team.ts
+++ b/src/game/Team.ts
@@ -1,0 +1,21 @@
+import { Player } from "./player/Player";
+
+export class Team {
+    private color: number[] = [0, 0, 0];
+
+    constructor(color: number[]) {
+        this.color = color;
+    }
+
+    /**
+     * Generates a new color for a player in this team, close to the team color.
+     * @returns The new color.
+     */
+    getNewPlayerColor(): number[] {
+        // return a random color, close to the team color
+        let r = this.color[0] + Math.floor(Math.random() * 32 - 16);
+        let g = this.color[1] + Math.floor(Math.random() * 32 - 16);
+        let b = this.color[2] + Math.floor(Math.random() * 32 - 16);
+        return [r, g, b];
+    }
+}

--- a/src/game/Team.ts
+++ b/src/game/Team.ts
@@ -1,5 +1,3 @@
-import { Player } from "./player/Player";
-
 export class Team {
     private color: number[] = [0, 0, 0];
 

--- a/src/game/action/AttackActionHandler.ts
+++ b/src/game/action/AttackActionHandler.ts
@@ -28,22 +28,29 @@ class AttackActionHandler implements GameTickListener {
 	}
 
 	//TODO: Move this out of here
-	preprocessAttack(player: number, target: number, percentage: number): void {
-		if (player === target || target === territoryManager.OWNER_NONE - 1) {
-			return;
-		}
+    preprocessAttack(player: number, target: number, percentage: number): void {
+        console.log("Attack: " + player + " -> " + target + " (" + percentage + ")");
+        if (player === target || target === territoryManager.OWNER_NONE - 1) {
+            return;
+        }
 
-		let troopCount = Math.floor(playerManager.getPlayer(player).getTroops() * percentage);
-		playerManager.getPlayer(player).removeTroops(troopCount);
+        if (target !== territoryManager.OWNER_NONE) {
+            if (playerManager.getPlayer(player).team === playerManager.getPlayer(target).team) {
+                return;
+            }
+        }
 
-		if (target === territoryManager.OWNER_NONE) {
-			this.attackUnclaimed(playerManager.getPlayer(player), troopCount);
-			return;
-		}
-		this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount);
-	}
+        let troopCount = Math.floor(playerManager.getPlayer(player).getTroops() * percentage);
+        playerManager.getPlayer(player).removeTroops(troopCount);
 
-	/**
+        if (target === territoryManager.OWNER_NONE) {
+            this.attackUnclaimed(playerManager.getPlayer(player), troopCount);
+            return;
+        }
+        this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount);
+    }
+
+    /**
 	 * Schedule an attack on an unclaimed territory.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.

--- a/src/game/action/AttackActionHandler.ts
+++ b/src/game/action/AttackActionHandler.ts
@@ -32,7 +32,6 @@ class AttackActionHandler implements GameTickListener {
 
 	//TODO: Move this out of here
     preprocessAttack(player: number, target: number, percentage: number): void {
-        console.log("Attack: " + player + " -> " + target + " (" + percentage + ")");
         if (player === target || target === territoryManager.OWNER_NONE - 1) {
             return;
         }

--- a/src/game/action/DonateExecutor.ts
+++ b/src/game/action/DonateExecutor.ts
@@ -1,0 +1,24 @@
+import { Player } from "../player/Player";
+
+export class DonateExecutor {
+    readonly player: Player;
+    readonly target: Player;
+    private troops: number;
+
+    constructor(player: Player, target: Player, troops: number) {
+        this.player = player;
+        this.target = target;
+        this.troops = troops;
+    }
+
+    /**
+     * Transfer troops from the player to the target.
+     */
+    runDonation(): void {
+        if (this.player.getTroops() < this.troops) {
+            this.troops = this.player.getTroops();
+        }
+        this.target.addTroops(this.troops * 0.9);
+        this.player.removeTroops(this.troops);
+    }
+}

--- a/src/game/action/DonateExecutor.ts
+++ b/src/game/action/DonateExecutor.ts
@@ -1,4 +1,4 @@
-import { Player } from "../player/Player";
+import {Player} from "../player/Player";
 
 export class DonateExecutor {
     readonly player: Player;

--- a/src/game/action/DonateExecutor.ts
+++ b/src/game/action/DonateExecutor.ts
@@ -18,7 +18,7 @@ export class DonateExecutor {
         if (this.player.getTroops() < this.troops) {
             this.troops = this.player.getTroops();
         }
-        this.target.addTroops(this.troops * 0.9);
+        this.target.addTroops(Math.ceil(this.troops * 0.9));
         this.player.removeTroops(this.troops);
     }
 }

--- a/src/game/player/BotPlayer.ts
+++ b/src/game/player/BotPlayer.ts
@@ -11,6 +11,7 @@ export class BotPlayer extends Player {
     }
 
 	//TODO: Implement bot logic
+    //Note attacks are treated the same as donations, so the bot may donate to bordering teammates.
 	tick(): void {
 		if (random.nextInt(20) < 19) return;
 		let targets: number[] = [];

--- a/src/game/player/BotPlayer.ts
+++ b/src/game/player/BotPlayer.ts
@@ -3,11 +3,12 @@ import {territoryManager} from "../TerritoryManager";
 import {random} from "../Random";
 import {attackActionHandler} from "../action/AttackActionHandler";
 import {onNeighbors} from "../../util/MathUtil";
+import { Team } from "../Team";
 
 export class BotPlayer extends Player {
-	constructor(id: number) {
-		super(id, "Bot", Math.floor(Math.random() * 256), Math.floor(Math.random() * 256), Math.floor(Math.random() * 256));
-	}
+    constructor(id: number, team: Team = null) {
+        super(id, "Bot", team);
+    }
 
 	//TODO: Implement bot logic
 	tick(): void {

--- a/src/game/player/BotPlayer.ts
+++ b/src/game/player/BotPlayer.ts
@@ -3,7 +3,7 @@ import {territoryManager} from "../TerritoryManager";
 import {random} from "../Random";
 import {attackActionHandler} from "../action/AttackActionHandler";
 import {onNeighbors} from "../../util/MathUtil";
-import { Team } from "../Team";
+import {Team} from "../Team";
 
 export class BotPlayer extends Player {
     constructor(id: number, team: Team = null) {

--- a/src/game/player/Player.ts
+++ b/src/game/player/Player.ts
@@ -3,6 +3,7 @@ import {territoryRenderer} from "../../renderer/layer/TerritoryRenderer";
 import {onNeighbors} from "../../util/MathUtil";
 import {playerNameRenderingManager} from "../../renderer/manager/PlayerNameRenderingManager";
 import {attackActionHandler} from "../action/AttackActionHandler";
+import {Team} from "../Team";
 
 export class Player {
 	readonly id: number;
@@ -11,17 +12,26 @@ export class Player {
 	readonly borderTiles: Set<number> = new Set();
 	private territorySize: number = 0;
 	private alive: boolean = true;
+    team: Team;
 
-	constructor(id: number, name: string, r: number, g: number, b: number) {
-		this.id = id;
-		this.name = name;
-		this.territoryR = r;
-		this.territoryG = g;
-		this.territoryB = b;
-		this.borderR = r < 128 ? r + 32 : r - 32;
-		this.borderG = g < 128 ? g + 32 : g - 32;
-		this.borderB = b < 128 ? b + 32 : b - 32;
-	}
+    constructor(id: number, name: string, team: Team = null) {
+        this.id = id;
+        this.name = name;
+        if (team) {
+            this.team = team;
+            let colors = team.getNewPlayerColor();
+            this.territoryR = colors[0];
+            this.territoryG = colors[1];
+            this.territoryB = colors[2];
+        } else {
+            this.territoryR = Math.floor(Math.random() * 256);
+            this.territoryG = Math.floor(Math.random() * 256);
+            this.territoryB = Math.floor(Math.random() * 256);
+        }
+        this.borderR = this.territoryR < 128 ? this.territoryR + 32 : this.territoryR - 32;
+        this.borderG = this.territoryG < 128 ? this.territoryG + 32 : this.territoryG - 32;
+        this.borderB = this.territoryB < 128 ? this.territoryB + 32 : this.territoryB - 32;
+    }
 
 	//TODO: remove this
 	territoryR: number = 0;

--- a/src/game/player/Player.ts
+++ b/src/game/player/Player.ts
@@ -12,7 +12,7 @@ export class Player {
 	readonly borderTiles: Set<number> = new Set();
 	private territorySize: number = 0;
 	private alive: boolean = true;
-    team: Team;
+    team: Team = null;
 
     constructor(id: number, name: string, team: Team = null) {
         this.id = id;

--- a/src/game/player/PlayerManager.ts
+++ b/src/game/player/PlayerManager.ts
@@ -19,13 +19,14 @@ class PlayerManager implements GameTickListener {
      * @param humans human players, one for local games, multiple for online games.
      * @param clientId Player ID of the client player (the player that is controlled this client).
      * @param maxPlayers The maximum number of players.
+     * @param teams The number of teams (0 for none).
      */
-    init(humans: Player[], clientId: number, maxPlayers: number, teams: boolean = false): void {
+    init(humans: Player[], clientId: number, maxPlayers: number, teams: number = 0): void {
         this.players = [];
         this.bots = [];
 
         if (teams) {
-            this.generateTeams(2);
+            this.generateTeams(teams);
         }
 
         clientPlayer = humans[clientId];

--- a/src/game/player/PlayerManager.ts
+++ b/src/game/player/PlayerManager.ts
@@ -3,34 +3,52 @@ import {BotPlayer} from "./BotPlayer";
 import {spawnManager} from "./SpawnManager";
 import {gameTicker, GameTickListener} from "../GameTicker";
 import {playerNameRenderingManager} from "../../renderer/manager/PlayerNameRenderingManager";
+import {Team} from "../Team";
 
 class PlayerManager implements GameTickListener {
 	private players: Player[];
 	private bots: BotPlayer[];
+    private teams: Team[];
 
-	constructor() {
-		gameTicker.registry.register(this);
-	}
+    constructor() {
+        gameTicker.registry.register(this);
+    }
 
-	/**
-	 * Initializes the player manager with the given players.
-	 * @param humans human players, one for local games, multiple for online games.
-	 * @param clientId Player ID of the client player (the player that is controlled this client).
-	 * @param maxPlayers The maximum number of players.
-	 */
-	init(humans: Player[], clientId: number, maxPlayers: number): void {
-		this.players = [];
-		this.bots = [];
+    /**
+     * Initializes the player manager with the given players.
+     * @param humans human players, one for local games, multiple for online games.
+     * @param clientId Player ID of the client player (the player that is controlled this client).
+     * @param maxPlayers The maximum number of players.
+     */
+    init(humans: Player[], clientId: number, maxPlayers: number, teams: boolean = false): void {
+        this.players = [];
+        this.bots = [];
 
-		clientPlayer = humans[clientId];
-		for (const player of humans) {
-			this.registerPlayer(player, false);
-		}
+        if (teams) {
+            this.generateTeams(2);
+        }
 
-		for (let i = humans.length; i < maxPlayers; i++) {
-			this.registerPlayer(new BotPlayer(this.players.length), true);
-		}
-	}
+        clientPlayer = humans[clientId];
+        for (const player of humans) {
+            if (teams) {
+                let teamedPlayer = new Player(this.players.length, player.name, this.teams[0]);
+                this.registerPlayer(teamedPlayer, false);
+            } else {
+                this.registerPlayer(player, false);
+            }
+            
+        }
+
+        for (let i = humans.length; i < maxPlayers; i++) {
+            let botPlayer: BotPlayer;
+            if (teams) {
+                botPlayer = new BotPlayer(this.players.length, this.teams[i % this.teams.length]);
+            } else {
+                botPlayer = new BotPlayer(this.players.length);
+            }
+            this.registerPlayer(botPlayer, true);
+        }
+    }
 
 	/**
 	 * Register a player.
@@ -61,6 +79,17 @@ class PlayerManager implements GameTickListener {
 			this.players.forEach(player => player.income());
 		}
 	}
+
+    /**
+     * Generate the teams for the game.
+     * @param numTeams The number of teams.
+     */
+    generateTeams(numTeams: number): void {
+        this.teams = [];
+        for (let i = 0; i < numTeams; i++) {
+            this.teams.push(new Team([Math.floor(Math.random() * 256), Math.floor(Math.random() * 256), Math.floor(Math.random() * 256)]));
+        }
+    }
 }
 
 export const playerManager = new PlayerManager();


### PR DESCRIPTION
- Added team functionality via a new Team class, which is stored as an attribute of each player. Number of teams is customizable when initializing the player manager.
- Donations are handled by a DonationExecutor class, based off the corresponding class for attacks. Its fairly barebones, but can be edited easily if we want to do something with donations.
    - Donations are treated the same as an attack, so clicking on a teammate executes a donation instead.
- This depends on a few parts marked for removal/refactoring, but it should be moved easily enough.