### PR TITLE
Fix bug: boat attack expanding from all borders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "warfront-client",
       "devDependencies": {
+        "@eslint/js": "^9.7.0",
         "eslint": "^9.7.0",
         "html-inline-script-webpack-plugin": "^3.2.1",
         "html-webpack-plugin": "^5.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "warfront-client",
       "devDependencies": {
-        "@eslint/js": "^9.7.0",
         "eslint": "^9.7.0",
         "html-inline-script-webpack-plugin": "^3.2.1",
         "html-webpack-plugin": "^5.6.0",

--- a/src/game/attack/AttackActionHandler.ts
+++ b/src/game/attack/AttackActionHandler.ts
@@ -64,7 +64,7 @@ class AttackActionHandler {
 	 * Schedule an attack on an unclaimed territory.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If not 
+	 * @param borderTiles The tiles from which the attack is executed, or null to use the player's border tiles.
 	 */
 	attackUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const parent = this.unclaimedIndex[player.id];
@@ -81,7 +81,7 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
+	 * @param borderTiles The tiles from which the attack is executed, or null to use the player's border tiles.
 	 */
 	attackPlayer(player: Player, target: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const parent = this.getAttack(player, target);
@@ -115,7 +115,7 @@ class AttackActionHandler {
 	 * Add an unclaimed attack to the list of ongoing attacks.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
+	 * @param borderTiles The tiles from which the attack is executed, or null to use the player's border tiles.
 	 * @private
 	 */
 	private addUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null = null): void {
@@ -131,7 +131,7 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
+	 * @param borderTiles The tiles from which the attack is executed, or null to use the player's border tiles.
 	 * @private
 	 */
 	private addAttack(player: Player, target: Player, troops: number, borderTiles: Set<number> | null = null): void {

--- a/src/game/attack/AttackActionHandler.ts
+++ b/src/game/attack/AttackActionHandler.ts
@@ -33,10 +33,10 @@ class AttackActionHandler {
 		playerManager.getPlayer(player).removeTroops(troopCount);
 
 		if (target === territoryManager.OWNER_NONE) {
-			this.attackUnclaimed(playerManager.getPlayer(player), troopCount, null);
+			this.attackUnclaimed(playerManager.getPlayer(player), troopCount);
 			return;
 		}
-		this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount, null);
+		this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount);
 	}
 
 	//TODO: Remove this once we have proper attack buttons
@@ -64,9 +64,9 @@ class AttackActionHandler {
 	 * Schedule an attack on an unclaimed territory.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
+	 * @param borderTiles The tiles from which the attack is executed. If not 
 	 */
-	attackUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null): void {
+	attackUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const parent = this.unclaimedIndex[player.id];
 		if (parent) {
 			parent.modifyTroops(troops);
@@ -81,9 +81,9 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
+	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
 	 */
-	attackPlayer(player: Player, target: Player, troops: number, borderTiles: Set<number> | null): void {
+	attackPlayer(player: Player, target: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const parent = this.getAttack(player, target);
 		if (parent) {
 			parent.modifyTroops(troops);
@@ -115,10 +115,10 @@ class AttackActionHandler {
 	 * Add an unclaimed attack to the list of ongoing attacks.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
+	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
 	 * @private
 	 */
-	private addUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null): void {
+	private addUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const attack = new AttackExecutor(player, null, troops, borderTiles);
 		this.attacks.push(attack);
 		this.unclaimedIndex[player.id] = attack;
@@ -131,10 +131,10 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
+	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
 	 * @private
 	 */
-	private addAttack(player: Player, target: Player, troops: number, borderTiles: Set<number> | null): void {
+	private addAttack(player: Player, target: Player, troops: number, borderTiles: Set<number> | null = null): void {
 		const attack = new AttackExecutor(player, target, troops, borderTiles);
 		this.attacks.push(attack);
 		this.playerIndex[player.id][target.id] = attack;

--- a/src/game/attack/AttackActionHandler.ts
+++ b/src/game/attack/AttackActionHandler.ts
@@ -33,10 +33,10 @@ class AttackActionHandler {
 		playerManager.getPlayer(player).removeTroops(troopCount);
 
 		if (target === territoryManager.OWNER_NONE) {
-			this.attackUnclaimed(playerManager.getPlayer(player), troopCount);
+			this.attackUnclaimed(playerManager.getPlayer(player), troopCount, null);
 			return;
 		}
-		this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount);
+		this.attackPlayer(playerManager.getPlayer(player), playerManager.getPlayer(target), troopCount, null);
 	}
 
 	//TODO: Remove this once we have proper attack buttons
@@ -64,15 +64,16 @@ class AttackActionHandler {
 	 * Schedule an attack on an unclaimed territory.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
+	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
 	 */
-	attackUnclaimed(player: Player, troops: number): void {
+	attackUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null): void {
 		const parent = this.unclaimedIndex[player.id];
 		if (parent) {
 			parent.modifyTroops(troops);
 			return;
 		}
 
-		this.addUnclaimed(player, troops);
+		this.addUnclaimed(player, troops, borderTiles);
 	}
 
 	/**
@@ -80,8 +81,9 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
+	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
 	 */
-	attackPlayer(player: Player, target: Player, troops: number): void {
+	attackPlayer(player: Player, target: Player, troops: number, borderTiles: Set<number> | null): void {
 		const parent = this.getAttack(player, target);
 		if (parent) {
 			parent.modifyTroops(troops);
@@ -95,7 +97,7 @@ class AttackActionHandler {
 			troops -= opposite.getTroops();
 		}
 
-		this.addAttack(player, target, troops);
+		this.addAttack(player, target, troops, borderTiles);
 	}
 
 	/**
@@ -113,10 +115,11 @@ class AttackActionHandler {
 	 * Add an unclaimed attack to the list of ongoing attacks.
 	 * @param player The player that is attacking.
 	 * @param troops The amount of troops that are attacking.
+	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
 	 * @private
 	 */
-	private addUnclaimed(player: Player, troops: number): void {
-		const attack = new AttackExecutor(player, null, troops);
+	private addUnclaimed(player: Player, troops: number, borderTiles: Set<number> | null): void {
+		const attack = new AttackExecutor(player, null, troops, borderTiles);
 		this.attacks.push(attack);
 		this.unclaimedIndex[player.id] = attack;
 		this.playerAttackList[player.id].push(attack);
@@ -128,10 +131,11 @@ class AttackActionHandler {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked.
 	 * @param troops The amount of troops that are attacking.
+	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
 	 * @private
 	 */
-	private addAttack(player: Player, target: Player, troops: number): void {
-		const attack = new AttackExecutor(player, target, troops);
+	private addAttack(player: Player, target: Player, troops: number, borderTiles: Set<number> | null): void {
+		const attack = new AttackExecutor(player, target, troops, borderTiles);
 		this.attacks.push(attack);
 		this.playerIndex[player.id][target.id] = attack;
 		this.playerAttackList[player.id].push(attack);

--- a/src/game/attack/AttackExecutor.ts
+++ b/src/game/attack/AttackExecutor.ts
@@ -11,6 +11,7 @@ import {playerNameRenderingManager} from "../../renderer/manager/PlayerNameRende
 export class AttackExecutor {
 	readonly player: Player;
 	readonly target: Player | null;
+	readonly borderTiles: Set<number> | null;
 	private troops: number;
 	private tileQueue: PriorityQueue<[number, number]> = new PriorityQueue((a, b) => a[0] < b[0]);
 	private basePriority: number = 0;
@@ -20,11 +21,13 @@ export class AttackExecutor {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked, or null if the target is unclaimed territory.
 	 * @param troops The amount of troops that are attacking.
+	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
 	 */
-	constructor(player: Player, target: Player | null, troops: number) {
+	constructor(player: Player, target: Player | null, troops: number, borderTiles: Set<number> | null) {
 		this.player = player;
 		this.target = target;
 		this.troops = troops;
+		this.borderTiles = borderTiles;
 		this.orderTiles();
 	}
 
@@ -122,7 +125,7 @@ export class AttackExecutor {
 
 		const result = [];
 		const amountCache = attackActionHandler.amountCache;
-		for (const tile of this.player.borderTiles) {
+		for (const tile of this.borderTiles || this.player.borderTiles) {
 			const x = tile % gameMap.width;
 			const y = Math.floor(tile / gameMap.width);
 			if (x > 0 && tileOwners[tile - 1] === target) {

--- a/src/game/attack/AttackExecutor.ts
+++ b/src/game/attack/AttackExecutor.ts
@@ -11,7 +11,6 @@ import {playerNameRenderingManager} from "../../renderer/manager/PlayerNameRende
 export class AttackExecutor {
 	readonly player: Player;
 	readonly target: Player | null;
-	readonly borderTiles: Set<number> | null;
 	private troops: number;
 	private tileQueue: PriorityQueue<[number, number]> = new PriorityQueue((a, b) => a[0] < b[0]);
 	private basePriority: number = 0;
@@ -21,14 +20,13 @@ export class AttackExecutor {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked, or null if the target is unclaimed territory.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed. If it is null, it will be the player's border tiles by default.
+	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
 	 */
-	constructor(player: Player, target: Player | null, troops: number, borderTiles: Set<number> | null) {
+	constructor(player: Player, target: Player | null, troops: number, borderTiles: Set<number> | null = null) {
 		this.player = player;
 		this.target = target;
 		this.troops = troops;
-		this.borderTiles = borderTiles;
-		this.orderTiles();
+		this.orderTiles(borderTiles);
 	}
 
 	/**
@@ -117,15 +115,16 @@ export class AttackExecutor {
 
 	/**
 	 * Build the initial tile queue.
+	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
 	 * @private
 	 */
-	private orderTiles(): void {
+	private orderTiles(borderTiles: Set<number> | null = null): void {
 		const tileOwners = territoryManager.tileOwners;
 		const target = this.target ? this.target.id : territoryManager.OWNER_NONE;
 
 		const result = [];
 		const amountCache = attackActionHandler.amountCache;
-		for (const tile of this.borderTiles || this.player.borderTiles) {
+		for (const tile of borderTiles || this.player.borderTiles) {
 			const x = tile % gameMap.width;
 			const y = Math.floor(tile / gameMap.width);
 			if (x > 0 && tileOwners[tile - 1] === target) {

--- a/src/game/attack/AttackExecutor.ts
+++ b/src/game/attack/AttackExecutor.ts
@@ -20,7 +20,7 @@ export class AttackExecutor {
 	 * @param player The player that is attacking.
 	 * @param target The player that is being attacked, or null if the target is unclaimed territory.
 	 * @param troops The amount of troops that are attacking.
-	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
+	 * @param borderTiles The tiles from which the attack is executed, or null to use the player's border tiles.
 	 */
 	constructor(player: Player, target: Player | null, troops: number, borderTiles: Set<number> | null = null) {
 		this.player = player;
@@ -115,7 +115,7 @@ export class AttackExecutor {
 
 	/**
 	 * Build the initial tile queue.
-	 * @param borderTiles The tiles from which the attack is executed, or null if its going to executed from player's border tiles.
+	 * @param borderTiles The tiles to calculate initial tile queue from, or null to use the player's border tiles.
 	 * @private
 	 */
 	private orderTiles(borderTiles: Set<number> | null = null): void {

--- a/src/game/boat/Boat.ts
+++ b/src/game/boat/Boat.ts
@@ -113,9 +113,9 @@ export class Boat {
 				playerNameRenderingManager.applyTransaction(this.owner, playerManager.getPlayer(target) || this.owner);
 
 				if (target === territoryManager.OWNER_NONE) {
-					attackActionHandler.attackUnclaimed(this.owner, this.troops);
+					attackActionHandler.attackUnclaimed(this.owner, this.troops, new Set([this.currentPath[this.currentNode]]));
 				} else {
-					attackActionHandler.attackPlayer(this.owner, playerManager.getPlayer(target), this.troops);
+					attackActionHandler.attackPlayer(this.owner, playerManager.getPlayer(target), this.troops, new Set([this.currentPath[this.currentNode]]));
 				}
 			}
 			boatManager.unregisterBoat(this);


### PR DESCRIPTION
Bug fix: Previously, when a boat landed on a target (either a bot or free land), the player would expand from every border as if it were a normal attack. Now, when a boat lands, it expands only from the landing point. This fix involved adding "borderTiles" to the AttackExecutor. "borderTiles" is a set that determines the origin of the attack. If it is set to null, the player’s border tiles are used as before. This change was implemented to make an infrastructure for adding/modding attack types in the future.